### PR TITLE
Truncate playback on start time/duration/end time

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ Or if you're using Bundler, add this to your Gemfile
 
 * `-c` Output audio to the given channel(s).  Eg `-c 0,1` will direct audio to channels 0 and 1.  Defaults to use channels 0 and 1 on the selected device
 
+* `-d` Duration. Will stop after the given amount of time.  Eg `-d 56` stops after 56 seconds of playback
+
+* `-e` End position. Will stop at the given absolute time, irregardless of seek. Eg `-e 56` stops at 56 seconds. `-s 01:09:30 -e 01:10:00` stops at 1 hour 10 minutes after 30 seconds of playback
+
 * `-o` Output device id or name.  Defaults to the system default
+
+* `-s` Seek  to given time position. Eg `-s 56` seeks to 56 seconds and `-s 01:10:00` seeks to 1 hour 10 min.
 
 * `-v` or `--verbose` Verbose
 

--- a/bin/playback
+++ b/bin/playback
@@ -14,10 +14,16 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 #
 # * `-c` Output audio to the given channel(s).  Eg `-c 0,1` will direct audio to channels 0 and 1.  Defaults to use channels 0 and 1 on the selected device
 #
+# * `-d` Duration. Will stop after the given amount of time.  Eg `-d 56` stops after 56 seconds of playback
+#
+# * `-e` End position. Will stop at the given absolute time, irregardless of seek. Eg `-e 56` stops at 56 seconds. `-s 01:09:30 -e 01:10:00` stops at 1 hour 10 minutes after 30 seconds of playback
+#
 # * `-o` Output device id or name.  Defaults to the system default
 #
+# * `-s` Seek  to given time position. Eg `-s 56` seeks to 56 seconds and `-s 01:10:00` seeks to 1 hour 10 min.
+#
 # * `-v` or `--verbose` Verbose
-# 
+#
 # * `--list-devices` List the available audio output devices
 #
 #

--- a/examples/play_snippet.rb
+++ b/examples/play_snippet.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+$:.unshift(File.join("..", "lib"))
+
+# Select one of the test files for playback
+
+require "audio-playback"
+
+MEDIA_DIRECTORY = "../test/media"
+
+# Select an output
+@output = AudioPlayback::Device::Output.gets
+
+# Find audio files
+audio_files = Dir.entries(MEDIA_DIRECTORY)
+audio_files.reject! { |file| file.match(/^\.{1,2}$/) }
+
+puts
+puts "Select an audio file..."
+
+# Print list of files
+audio_files.each_with_index { |file, i| puts("#{i+1}. #{file}") }
+puts
+
+# Prompt user to select a file
+filename = nil
+while filename.nil? do
+  print("> ")
+  choice = gets
+  index = choice.chomp.to_i - 1
+  filename = audio_files[index]
+end
+
+# Play file from 0:01.5 to 0:02.3
+@playback = AudioPlayback.play("#{MEDIA_DIRECTORY}/#{filename}", :output_device => @output, :seek => 1.5, :duration => 0.8)
+@playback.block

--- a/lib/audio-playback.rb
+++ b/lib/audio-playback.rb
@@ -31,8 +31,11 @@ module AudioPlayback
   # @param [Hash] options
   # @option options [Fixnum] :buffer_size Buffer size in bytes.  Defaults to 4096
   # @option options [Array<Fixnum>, Fixnum] :channels (or: :channel) Output audio to the given channel(s).  Eg `:channels => [0,1]` will direct the audio to channels 0 and 1. Defaults to use all available channels
+  # @option options [Numeric] :duration Play for given time in seconds
+  # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
   # @option options [Float] :latency Latency in seconds.  Defaults to use the default latency for the selected output device
   # @option options [IO] :logger Logger object
+  # @option options [Numeric] :seek Start at given time position in seconds
   # @option options [Fixnum, String] :output_device (or: :output) Output device id or name
   def self.play(file_paths, options = {})
     sounds = Array(file_paths).map { |path| Sound.load(path, options) }

--- a/lib/audio-playback.rb
+++ b/lib/audio-playback.rb
@@ -19,6 +19,7 @@ require "audio-playback/playback"
 
 # classes
 require "audio-playback/file"
+require "audio-playback/position"
 require "audio-playback/sound"
 
 # Play audio files

--- a/lib/audio-playback/commandline.rb
+++ b/lib/audio-playback/commandline.rb
@@ -18,6 +18,20 @@ module AudioPlayback
         :name => "Direct to channel(s)"
       },
 
+      :duration => {
+        :short => "-d",
+        :long => "--duration [seconds]",
+        :name => "Duration",
+        :type => String
+      },
+
+      :end_position => {
+        :short => "-e",
+        :long => "--end-position [seconds]",
+        :name => "End position",
+        :type => String
+      },
+
       :latency => {
         :short => "-l",
         :long => "--latency [seconds]",
@@ -28,6 +42,13 @@ module AudioPlayback
       :list_devices => {
         :long => "--list-devices",
         :name => "List devices"
+      },
+
+      :seek => {
+        :short => "-s",
+        :long => "--seek [seconds]",
+        :name => "Seek",
+        :type => String
       },
 
       :logger => {
@@ -43,7 +64,7 @@ module AudioPlayback
         :type => String,
         :name => "Output device for playback"
       }
-    }
+    }.freeze
 
   end
 

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -143,10 +143,14 @@ module AudioPlayback
         #puts "Start point: #{start_frame}"
         end_frame = user_data.get_float32(Playback::METADATA.index(:end_frame) * Playback::FRAME_SIZE).to_i
         #puts "Duration: #{duration}"
+        counter += start_frame
         end_frame = [end_frame, audio_data_size].min
         is_eof = false
-        if counter >= end_frame - frames_per_buffer
-          if counter < end_frame
+        end_window = end_frame - frames_per_buffer
+        if counter >= end_window
+          if counter == end_frame
+            is_eof = true
+          elsif counter < end_frame
             buffer_size = end_frame.divmod(frames_per_buffer).last
             #puts "Truncated buffer size: #{buffer_size}"
             difference = frames_per_buffer - buffer_size
@@ -154,6 +158,7 @@ module AudioPlayback
             extra_data = [0] * difference * num_channels
             is_eof = true
           else
+            p "Aborting (counter: #{counter}, end_frame: #{end_frame})"
             return :paAbort
           end
         end

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -54,7 +54,8 @@ module AudioPlayback
       def block
         begin
           while active?
-            sleep(0.0001)
+            p Time.now.to_f
+            sleep(0.1)
           end
           while FFI::PortAudio::API.Pa_IsStreamActive(@stream.read_pointer) != :paNoError
             sleep(1)

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -54,7 +54,6 @@ module AudioPlayback
       def block
         begin
           while active?
-            p Time.now.to_f
             sleep(0.1)
           end
           while FFI::PortAudio::API.Pa_IsStreamActive(@stream.read_pointer) != :paNoError

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -54,7 +54,7 @@ module AudioPlayback
       def block
         begin
           while active?
-            sleep(0.1)
+            sleep(0.001)
           end
           while FFI::PortAudio::API.Pa_IsStreamActive(@stream.read_pointer) != :paNoError
             sleep(1)

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -143,7 +143,6 @@ module AudioPlayback
         #puts "Start point: #{start_frame}"
         end_frame = user_data.get_float32(Playback::METADATA.index(:end_frame) * Playback::FRAME_SIZE).to_i
         #puts "Duration: #{duration}"
-        counter += start_frame
         end_frame = [end_frame, audio_data_size].min
         is_eof = false
         end_window = end_frame - frames_per_buffer
@@ -158,7 +157,7 @@ module AudioPlayback
             extra_data = [0] * difference * num_channels
             is_eof = true
           else
-            p "Aborting (counter: #{counter}, end_frame: #{end_frame})"
+            # p "Aborting (counter: #{counter}, end_frame: #{end_frame})"
             return :paAbort
           end
         end

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -135,14 +135,19 @@ module AudioPlayback
         #puts "Entering callback at #{Time.now.to_f}"
         counter = user_data.get_float32(Playback::METADATA.index(:pointer) * Playback::FRAME_SIZE).to_i
         #puts "Frame: #{counter}"
-        sample_size = user_data.get_float32(Playback::METADATA.index(:size) * Playback::FRAME_SIZE).to_i
-        #puts "Sample size: #{sample_size}"
+        audio_data_size = user_data.get_float32(Playback::METADATA.index(:size) * Playback::FRAME_SIZE).to_i
+        #puts "Sample size: #{audio_data_size}"
         num_channels = user_data.get_float32(Playback::METADATA.index(:num_channels) * Playback::FRAME_SIZE).to_i
         #puts "Num Channels: #{num_channels}"
+        start_frame = user_data.get_float32(Playback::METADATA.index(:start_frame) * Playback::FRAME_SIZE).to_i
+        #puts "Start point: #{start_frame}"
+        end_frame = user_data.get_float32(Playback::METADATA.index(:end_frame) * Playback::FRAME_SIZE).to_i
+        #puts "Duration: #{duration}"
+        end_frame = [end_frame, audio_data_size].min
         is_eof = false
-        if counter >= sample_size - frames_per_buffer
-          if counter < sample_size
-            buffer_size = sample_size.divmod(frames_per_buffer).last
+        if counter >= end_frame - frames_per_buffer
+          if counter < end_frame
+            buffer_size = end_frame.divmod(frames_per_buffer).last
             #puts "Truncated buffer size: #{buffer_size}"
             difference = frames_per_buffer - buffer_size
             #puts "Adding #{difference} frames of null audio"
@@ -154,7 +159,7 @@ module AudioPlayback
         end
         buffer_size ||= frames_per_buffer
         #puts "Size per buffer per channel: #{frames_per_buffer}"
-        offset = ((counter * num_channels) + Playback::METADATA.count) * Playback::FRAME_SIZE
+        offset = (((counter + start_frame) * num_channels) + Playback::METADATA.count) * Playback::FRAME_SIZE
         #puts "Starting at location: #{offset}"
         data = user_data.get_array_of_float32(offset, buffer_size * num_channels)
         data += extra_data unless extra_data.nil?

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -180,6 +180,13 @@ module AudioPlayback
         (num_seconds * sample_rate).to_i
       end
 
+      # Are the options for truncation valid? eg is the :end_position option after the
+      # :seek option?
+      # @param [Hash] options
+      # @option options [Numeric] :duration Play for given time in seconds
+      # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
+      # @option options [Numeric] :seek Start at given time position in seconds
+      # @return [Boolean]
       def truncate_valid?(options)
         options[:end_position].nil? || options[:seek].nil? ||
           options[:end_position] > options[:seek]

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -161,14 +161,16 @@ module AudioPlayback
       # @option options [Numeric] :seek Start at given time position in seconds
       # @return [Hash]
       def populate_truncation(options = {})
+        seek = Position.new(options[:seek]) unless options[:seek].nil?
+        duration = Position.new(options[:duration]) unless options[:duration].nil?
+        end_position = Position.new(options[:end_position]) unless options[:end_position].nil?
         @truncate = {}
-        seek = options[:seek]
-        end_position = if options[:duration].nil?
-          options[:end_position]
+        end_position = if duration.nil?
+          end_position
         elsif seek.nil?
-          options[:duration] || options[:end_position]
+          duration || end_position
         else
-          options[:duration] + seek || options[:end_position]
+          duration + seek || end_position
         end
         unless seek.nil?
           @truncate[:start_frame] = number_of_seconds_to_number_of_frames(seek)

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -117,7 +117,8 @@ module AudioPlayback
       # @return [Boolean]
       def validate_requested_channels(channels)
         if channels.count > @output.num_channels
-          raise InvalidChannels.new("Only #{@output.num_channels} channels available on #{@output.name} output")
+          message = "Only #{@output.num_channels} channels available on #{@output.name} output"
+          raise(InvalidChannels.new(message))
           false
         end
         true
@@ -215,10 +216,11 @@ module AudioPlayback
       def populate(options = {})
         populate_channels(options)
         if truncate_requested?(options)
-          if !truncate_valid?(options)
-            raise InvalidTruncation.new("Seek and end_position options are not valid")
-          else
+          if truncate_valid?(options)
             populate_truncation(options)
+          else
+            message = "Truncation options are not valid"
+            raise(InvalidTruncation.new(message))
           end
         end
         @data = StreamData.new(self)

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -162,20 +162,19 @@ module AudioPlayback
       # @return [Hash]
       def populate_truncation(options = {})
         @truncate = {}
-        duration = options[:duration]
-        if options[:seek].nil?
-          duration ||= options[:end_position]
+        seek = options[:seek]
+        end_position = if options[:duration].nil?
+          options[:end_position]
+        elsif seek.nil?
+          options[:duration] || options[:end_position]
         else
-          seek = options[:seek]
-          unless options[:end_position].nil?
-            duration ||= options[:end_position] - options[:seek]
-          end
+          options[:duration] + seek || options[:end_position]
         end
         unless seek.nil?
           @truncate[:start_frame] = number_of_seconds_to_number_of_frames(seek)
         end
-        unless duration.nil?
-          @truncate[:end_frame] = number_of_seconds_to_number_of_frames(duration)
+        unless end_position.nil?
+          @truncate[:end_frame] = number_of_seconds_to_number_of_frames(end_position)
         end
         @truncate
       end

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -13,7 +13,7 @@ module AudioPlayback
 
     FRAME_SIZE = FFI::TYPE_FLOAT32.size
 
-    METADATA = [:size, :num_channels, :pointer, :is_eof].freeze
+    METADATA = [:size, :num_channels, :start_frame, :end_frame, :pointer, :is_eof].freeze
 
     class InvalidChannels < RuntimeError
     end
@@ -172,10 +172,10 @@ module AudioPlayback
           end
         end
         unless seek.nil?
-          @truncate[:seek] = number_of_seconds_to_number_of_frames(seek)
+          @truncate[:start_frame] = number_of_seconds_to_number_of_frames(seek)
         end
         unless duration.nil?
-          @truncate[:duration] = number_of_seconds_to_number_of_frames(duration)
+          @truncate[:end_frame] = number_of_seconds_to_number_of_frames(duration)
         end
         @truncate
       end

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -15,6 +15,12 @@ module AudioPlayback
 
     METADATA = [:size, :num_channels, :pointer, :is_eof].freeze
 
+    class InvalidChannels < RuntimeError
+    end
+
+    class InvalidTruncation < RuntimeError
+    end
+
     # Action of playing back an audio file
     class Action
 
@@ -111,7 +117,7 @@ module AudioPlayback
       # @return [Boolean]
       def validate_requested_channels(channels)
         if channels.count > @output.num_channels
-          raise "Only #{@output.num_channels} channels available on #{@output.name} output"
+          raise InvalidChannels.new("Only #{@output.num_channels} channels available on #{@output.name} output")
           false
         end
         true
@@ -210,7 +216,7 @@ module AudioPlayback
         populate_channels(options)
         if truncate_requested?(options)
           if !truncate_valid?(options)
-            raise "Seek and end_position options are not valid"
+            raise InvalidTruncation.new("Seek and end_position options are not valid")
           else
             populate_truncation(options)
           end

--- a/lib/audio-playback/playback/frame_set.rb
+++ b/lib/audio-playback/playback/frame_set.rb
@@ -35,7 +35,7 @@ module AudioPlayback
       # @return [Array<Frame>]
       def truncate(data, playback)
         unless playback.truncate[:seek].nil?
-          data = data.slice(playback.truncate[:seek], data.length)
+          data = data.slice(playback.truncate[:seek]..-1)
         end
         unless playback.truncate[:duration].nil?
           data = data.slice(0, playback.truncate[:duration])

--- a/lib/audio-playback/playback/frame_set.rb
+++ b/lib/audio-playback/playback/frame_set.rb
@@ -25,21 +25,6 @@ module AudioPlayback
         data = ensure_array_frames(data)
         data = to_frame_objects(data)
         data = build_channels(data, playback) unless channels_match?(playback, sound)
-        data = truncate(data, playback) if playback.truncate?
-        data
-      end
-
-      # Truncate the frameset to the time constraints stored in the playback object
-      # @param [Array<Frame>] data
-      # @param [Playback::Action] playback
-      # @return [Array<Frame>]
-      def truncate(data, playback)
-        unless playback.truncate[:seek].nil?
-          data = data.slice(playback.truncate[:seek]..-1)
-        end
-        unless playback.truncate[:duration].nil?
-          data = data.slice(0, playback.truncate[:duration])
-        end
         data
       end
 

--- a/lib/audio-playback/playback/frame_set.rb
+++ b/lib/audio-playback/playback/frame_set.rb
@@ -7,7 +7,7 @@ module AudioPlayback
 
       extend Forwardable
 
-      def_delegators :@data, :[], :[]=, :flatten, :slice, :to_ary, :unshift
+      def_delegators :@data, :[], :[]=, :flatten, :length, :size, :slice, :to_ary, :unshift
 
       # @param [Playback::Action] playback
       def initialize(playback)
@@ -25,6 +25,21 @@ module AudioPlayback
         data = ensure_array_frames(data)
         data = to_frame_objects(data)
         data = build_channels(data, playback) unless channels_match?(playback, sound)
+        data = truncate(data, playback) if playback.truncate?
+        data
+      end
+
+      # Truncate the frameset to the time constraints stored in the playback object
+      # @param [Array<Frame>] data
+      # @param [Playback::Action] playback
+      # @return [Array<Frame>]
+      def truncate(data, playback)
+        unless playback.truncate[:seek].nil?
+          data = data.slice(playback.truncate[:seek], data.length)
+        end
+        unless playback.truncate[:duration].nil?
+          data = data.slice(0, playback.truncate[:duration])
+        end
         data
       end
 

--- a/lib/audio-playback/playback/stream_data.rb
+++ b/lib/audio-playback/playback/stream_data.rb
@@ -5,6 +5,10 @@ module AudioPlayback
     # Playback data for the Device::Stream
     class StreamData
 
+      extend Forwardable
+
+      def_delegators :@data, :length, :size
+
       # A C pointer version of the audio data
       # @param [Playback::Action] playback
       # @return [FFI::Pointer]
@@ -51,10 +55,11 @@ module AudioPlayback
       # Add playback metadata to the stream data
       # @return [FrameSet]
       def add_metadata
+        size = @data.size
         @data.unshift(0.0) # 3. is_eof
         @data.unshift(0.0) # 2. counter
         @data.unshift(@playback.output.num_channels.to_f) # 1. num_channels
-        @data.unshift(@playback.size.to_f) # 0. sample size
+        @data.unshift(size.to_f) # 0. frame set size (without metadata)
         @data
       end
 

--- a/lib/audio-playback/playback/stream_data.rb
+++ b/lib/audio-playback/playback/stream_data.rb
@@ -56,8 +56,14 @@ module AudioPlayback
       # @return [FrameSet]
       def add_metadata
         size = @data.size
-        @data.unshift(0.0) # 3. is_eof
-        @data.unshift(0.0) # 2. counter
+        @data.unshift(0.0) # 5. is_eof
+        @data.unshift(0.0) # 4. counter
+        if @playback.truncate?
+          end_frame = @playback.truncate[:end_frame]
+          start_frame = @playback.truncate[:start_frame]
+        end
+        @data.unshift(end_frame || size) # 3. end frame
+        @data.unshift(start_frame || 0.0) # 2. start frame
         @data.unshift(@playback.output.num_channels.to_f) # 1. num_channels
         @data.unshift(size.to_f) # 0. frame set size (without metadata)
         @data

--- a/lib/audio-playback/playback/stream_data.rb
+++ b/lib/audio-playback/playback/stream_data.rb
@@ -56,12 +56,12 @@ module AudioPlayback
       # @return [FrameSet]
       def add_metadata
         size = @data.size
-        @data.unshift(0.0) # 5. is_eof
-        @data.unshift(0.0) # 4. counter
         if @playback.truncate?
           end_frame = @playback.truncate[:end_frame]
           start_frame = @playback.truncate[:start_frame]
         end
+        @data.unshift(0.0) # 5. is_eof
+        @data.unshift(start_frame || 0.0) # 4. counter
         @data.unshift(end_frame || size) # 3. end frame
         @data.unshift(start_frame || 0.0) # 2. start frame
         @data.unshift(@playback.output.num_channels.to_f) # 1. num_channels

--- a/lib/audio-playback/position.rb
+++ b/lib/audio-playback/position.rb
@@ -1,5 +1,6 @@
 module AudioPlayback
 
+  # A time position in a sound
   class Position
 
     class InvalidTime < RuntimeError
@@ -13,34 +14,52 @@ module AudioPlayback
       3600 # hour
     ].freeze
 
+    # Time format like (hh:)(mm:)ss(.ss)
     FORMAT = /((\d+\:)(\d{2}\:)|(\d{2}\:))?\d{1,2}(\.\d+)?/.freeze
 
     attr_reader :seconds
     alias_method :to_seconds, :seconds
     def_delegators :@seconds, :to_f
 
+    # @param [Numeric, String] seconds_or_time Time as (hh:)(mm:)ss(.ss)
     def initialize(seconds_or_time)
       seconds_or_time = seconds_or_time.to_s
       validate_time(seconds_or_time)
       populate(seconds_or_time)
     end
 
+    # Multiply the seconds value of this Position by the given value
+    # @param [Numeric, Position] another
+    # @return [Float]
     def *(another)
       @seconds * another.to_f
     end
 
+    # Add the seconds value of this Position to the given value
+    # @param [Numeric, Position] another
+    # @return [Float]
     def +(another)
       @seconds + another.to_f
     end
 
     private
 
+    # Validate that the time that was passed into the constructor is in the correct
+    # format. Raises InvalidTime error if not
+    # @param [Numeric, String] seconds_or_time Time as (hh:)(mm:)ss(.ss)
+    # @return [Boolean]
     def validate_time(seconds_or_time)
       unless seconds_or_time.match(FORMAT)
         raise(InvalidTime)
       end
+      true
     end
 
+    # Validate that the segments of the time that was passed into the constructor
+    # are valid. For example that the minutes and or seconds values are below 60.
+    # Raises InvalidTime error if not
+    # @param [Array<String>] segments Time as [(hh), (mm), ss(.ss)]
+    # @return [Boolean]
     def validate_segments(segments)
       seconds = segments[0]
       minutes = segments[1]
@@ -49,8 +68,12 @@ module AudioPlayback
           raise(InvalidTime)
         end
       end
+      true
     end
 
+    # Populate the seconds ivar using the time that was passed into the constructor
+    # @param [Numeric, String] seconds_or_time Time as (hh:)(mm:)ss(.ss)
+    # @return [Float]
     def populate(seconds_or_time)
       segments = seconds_or_time.split(":").map(&:to_f).reverse
       validate_segments(segments)

--- a/lib/audio-playback/position.rb
+++ b/lib/audio-playback/position.rb
@@ -1,0 +1,54 @@
+module AudioPlayback
+
+  class Position
+
+    class InvalidTime < RuntimeError
+    end
+
+    UNITS = [
+      1, # second
+      60, # minute
+      3600 # hour
+    ].freeze
+
+    FORMAT = /((\d+\:)(\d{2}\:)|(\d{2}\:))?\d{1,2}(\.\d+)?/.freeze
+
+    attr_reader :seconds
+    alias_method :to_seconds, :seconds
+
+    def initialize(seconds_or_time)
+      validate_time(seconds_or_time)
+      populate(seconds_or_time)
+    end
+
+    private
+
+    def validate_time(seconds_or_time)
+      unless seconds_or_time.match(FORMAT)
+        raise(InvalidTime)
+      end
+    end
+
+    def validate_segments(segments)
+      seconds = segments[0]
+      minutes = segments[1]
+      [seconds, minutes].compact.each do |segment|
+        if segment >= 60
+          raise(InvalidTime)
+        end
+      end
+    end
+
+    def populate(seconds_or_time)
+      segments = seconds_or_time.split(":").map(&:to_f).reverse
+      validate_segments(segments)
+      @seconds = 0
+      segments.each_with_index do |segment, i|
+        @seconds += segment * UNITS[i]
+      end
+      @seconds
+    end
+
+  end
+
+end

--- a/lib/audio-playback/position.rb
+++ b/lib/audio-playback/position.rb
@@ -5,6 +5,8 @@ module AudioPlayback
     class InvalidTime < RuntimeError
     end
 
+    extend Forwardable
+
     UNITS = [
       1, # second
       60, # minute
@@ -15,10 +17,20 @@ module AudioPlayback
 
     attr_reader :seconds
     alias_method :to_seconds, :seconds
+    def_delegators :@seconds, :to_f
 
     def initialize(seconds_or_time)
+      seconds_or_time = seconds_or_time.to_s
       validate_time(seconds_or_time)
       populate(seconds_or_time)
+    end
+
+    def *(another)
+      @seconds * another.to_f
+    end
+
+    def +(another)
+      @seconds + another.to_f
     end
 
     private

--- a/test/playback/frame_set_test.rb
+++ b/test/playback/frame_set_test.rb
@@ -4,6 +4,181 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
 
   context "FrameSet" do
 
+    context "#truncate" do
+
+      setup do
+        @output = MockOutput.new(1, num_channels: 2)
+        @sample_rate = 44100
+      end
+
+      context "with no truncation" do
+
+        setup do
+          @path = "test/media/1-mono-#{@sample_rate}.wav"
+          @file = AudioPlayback::File.new(@path)
+          @sound = AudioPlayback::Sound.new(@file)
+          @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
+          @data = @sound.data
+          @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+        end
+
+        should "truncate to the corret length" do
+          refute_nil @frames
+          assert @frames.kind_of?(Array)
+          refute_empty @frames
+          assert @playback.size, @frames.length
+        end
+
+      end
+
+      context "with seek" do
+
+        context "mono file" do
+
+          setup do
+            @seek = 0.1
+            @path = "test/media/1-mono-#{@sample_rate}.wav"
+            @file = AudioPlayback::File.new(@path)
+            @sound = AudioPlayback::Sound.new(@file)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek)
+            @data = @sound.data
+            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+          end
+
+          should "truncate to the corret length" do
+            refute_nil @frames
+            assert @frames.kind_of?(Array)
+            refute_empty @frames
+            size = @playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i
+            assert size, @frames.length
+          end
+
+        end
+
+        context "stereo file" do
+
+          setup do
+            @seek = 0.2
+            @path = "test/media/1-stereo-#{@sample_rate}.wav"
+            @file = AudioPlayback::File.new(@path)
+            @sound = AudioPlayback::Sound.new(@file)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek)
+            @data = @sound.data
+            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+          end
+
+          should "truncate to the correct length" do
+            refute_nil @frames
+            assert @frames.kind_of?(Array)
+            refute_empty @frames
+            size = assert @playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i, @frames.length
+            assert size, @frames.length
+          end
+
+        end
+
+      end
+
+      context "with seek and duration" do
+
+        context "mono file" do
+
+          setup do
+            @seek = 0.3
+            @duration = 0.4
+            @path = "test/media/1-mono-#{@sample_rate}.wav"
+            @file = AudioPlayback::File.new(@path)
+            @sound = AudioPlayback::Sound.new(@file)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek, duration: @duration)
+            @data = @sound.data
+            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+          end
+
+          should "truncate to the corret length" do
+            refute_nil @frames
+            assert @frames.kind_of?(Array)
+            refute_empty @frames
+            size = [@playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i, (@duration * @sample_rate).to_i].min
+            assert size, @frames.length
+          end
+
+        end
+
+        context "stereo file" do
+
+          setup do
+            @seek = 0.5
+            @duration = 0.6
+            @path = "test/media/1-stereo-#{@sample_rate}.wav"
+            @file = AudioPlayback::File.new(@path)
+            @sound = AudioPlayback::Sound.new(@file)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek, duration: @duration)
+            @data = @sound.data
+            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+          end
+
+          should "truncate to the correct length" do
+            refute_nil @frames
+            assert @frames.kind_of?(Array)
+            refute_empty @frames
+            size = [@playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i, (@duration * @sample_rate).to_i].min
+            assert size, @frames.length
+          end
+
+        end
+
+      end
+
+      context "with duration" do
+
+        context "mono file" do
+
+          setup do
+            @duration = 0.7
+            @path = "test/media/1-mono-#{@sample_rate}.wav"
+            @file = AudioPlayback::File.new(@path)
+            @sound = AudioPlayback::Sound.new(@file)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), duration: @duration)
+            @data = @sound.data
+            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+          end
+
+          should "truncate to the corret length" do
+            refute_nil @frames
+            assert @frames.kind_of?(Array)
+            refute_empty @frames
+            size = [@playback.sounds.map(&:size).max, (@duration * @sample_rate).to_i].min
+            assert size, @frames.length
+          end
+
+        end
+
+        context "stereo file" do
+
+          setup do
+            @duration = 0.8
+            @path = "test/media/1-stereo-#{@sample_rate}.wav"
+            @file = AudioPlayback::File.new(@path)
+            @sound = AudioPlayback::Sound.new(@file)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), duration: 0.8)
+            @data = @sound.data
+            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
+          end
+
+          should "truncate to the correct length" do
+            refute_nil @frames
+            assert @frames.kind_of?(Array)
+            refute_empty @frames
+            size = [@playback.sounds.map(&:size).max, (@duration * @sample_rate).to_i].min
+            assert size, @frames.length
+          end
+
+        end
+
+      end
+
+    end
+
     context "#ensure_structure" do
 
       context "sound has same number of channels as output" do
@@ -14,8 +189,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-mono-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, :num_channels => 1)
-            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
+            @output = MockOutput.new(1, num_channels: 1)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end
@@ -37,8 +212,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-stereo-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, :num_channels => 2)
-            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
+            @output = MockOutput.new(1, num_channels: 2)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end
@@ -65,8 +240,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-mono-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, :num_channels => 2)
-            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
+            @output = MockOutput.new(1, num_channels: 2)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end
@@ -88,8 +263,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-stereo-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, :num_channels => 1)
-            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
+            @output = MockOutput.new(1, num_channels: 1)
+            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end

--- a/test/playback/frame_set_test.rb
+++ b/test/playback/frame_set_test.rb
@@ -4,181 +4,6 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
 
   context "FrameSet" do
 
-    context "#truncate" do
-
-      setup do
-        @output = MockOutput.new(1, num_channels: 2)
-        @sample_rate = 44100
-      end
-
-      context "with no truncation" do
-
-        setup do
-          @path = "test/media/1-mono-#{@sample_rate}.wav"
-          @file = AudioPlayback::File.new(@path)
-          @sound = AudioPlayback::Sound.new(@file)
-          @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
-          @data = @sound.data
-          @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-        end
-
-        should "truncate to the corret length" do
-          refute_nil @frames
-          assert @frames.kind_of?(Array)
-          refute_empty @frames
-          assert @playback.size, @frames.length
-        end
-
-      end
-
-      context "with seek" do
-
-        context "mono file" do
-
-          setup do
-            @seek = 0.1
-            @path = "test/media/1-mono-#{@sample_rate}.wav"
-            @file = AudioPlayback::File.new(@path)
-            @sound = AudioPlayback::Sound.new(@file)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek)
-            @data = @sound.data
-            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-          end
-
-          should "truncate to the corret length" do
-            refute_nil @frames
-            assert @frames.kind_of?(Array)
-            refute_empty @frames
-            size = @playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i
-            assert size, @frames.length
-          end
-
-        end
-
-        context "stereo file" do
-
-          setup do
-            @seek = 0.2
-            @path = "test/media/1-stereo-#{@sample_rate}.wav"
-            @file = AudioPlayback::File.new(@path)
-            @sound = AudioPlayback::Sound.new(@file)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek)
-            @data = @sound.data
-            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-          end
-
-          should "truncate to the correct length" do
-            refute_nil @frames
-            assert @frames.kind_of?(Array)
-            refute_empty @frames
-            size = assert @playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i, @frames.length
-            assert size, @frames.length
-          end
-
-        end
-
-      end
-
-      context "with seek and duration" do
-
-        context "mono file" do
-
-          setup do
-            @seek = 0.3
-            @duration = 0.4
-            @path = "test/media/1-mono-#{@sample_rate}.wav"
-            @file = AudioPlayback::File.new(@path)
-            @sound = AudioPlayback::Sound.new(@file)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek, duration: @duration)
-            @data = @sound.data
-            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-          end
-
-          should "truncate to the corret length" do
-            refute_nil @frames
-            assert @frames.kind_of?(Array)
-            refute_empty @frames
-            size = [@playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i, (@duration * @sample_rate).to_i].min
-            assert size, @frames.length
-          end
-
-        end
-
-        context "stereo file" do
-
-          setup do
-            @seek = 0.5
-            @duration = 0.6
-            @path = "test/media/1-stereo-#{@sample_rate}.wav"
-            @file = AudioPlayback::File.new(@path)
-            @sound = AudioPlayback::Sound.new(@file)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), seek: @seek, duration: @duration)
-            @data = @sound.data
-            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-          end
-
-          should "truncate to the correct length" do
-            refute_nil @frames
-            assert @frames.kind_of?(Array)
-            refute_empty @frames
-            size = [@playback.sounds.map(&:size).max - (@seek * @sample_rate).to_i, (@duration * @sample_rate).to_i].min
-            assert size, @frames.length
-          end
-
-        end
-
-      end
-
-      context "with duration" do
-
-        context "mono file" do
-
-          setup do
-            @duration = 0.7
-            @path = "test/media/1-mono-#{@sample_rate}.wav"
-            @file = AudioPlayback::File.new(@path)
-            @sound = AudioPlayback::Sound.new(@file)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), duration: @duration)
-            @data = @sound.data
-            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-          end
-
-          should "truncate to the corret length" do
-            refute_nil @frames
-            assert @frames.kind_of?(Array)
-            refute_empty @frames
-            size = [@playback.sounds.map(&:size).max, (@duration * @sample_rate).to_i].min
-            assert size, @frames.length
-          end
-
-        end
-
-        context "stereo file" do
-
-          setup do
-            @duration = 0.8
-            @path = "test/media/1-stereo-#{@sample_rate}.wav"
-            @file = AudioPlayback::File.new(@path)
-            @sound = AudioPlayback::Sound.new(@file)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output), duration: 0.8)
-            @data = @sound.data
-            @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
-          end
-
-          should "truncate to the correct length" do
-            refute_nil @frames
-            assert @frames.kind_of?(Array)
-            refute_empty @frames
-            size = [@playback.sounds.map(&:size).max, (@duration * @sample_rate).to_i].min
-            assert size, @frames.length
-          end
-
-        end
-
-      end
-
-    end
-
     context "#ensure_structure" do
 
       context "sound has same number of channels as output" do
@@ -189,8 +14,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-mono-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, num_channels: 1)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
+            @output = MockOutput.new(1, :num_channels => 1)
+            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end
@@ -212,8 +37,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-stereo-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, num_channels: 2)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
+            @output = MockOutput.new(1, :num_channels => 2)
+            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end
@@ -240,8 +65,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-mono-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, num_channels: 2)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
+            @output = MockOutput.new(1, :num_channels => 2)
+            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end
@@ -263,8 +88,8 @@ class AudioPlayback::Playback::FrameSetTest < Minitest::Test
             @path = "test/media/1-stereo-44100.wav"
             @file = AudioPlayback::File.new(@path)
             @sound = AudioPlayback::Sound.new(@file)
-            @output = MockOutput.new(1, num_channels: 1)
-            @playback = AudioPlayback::Playback.new(@sound, @output, stream: MockStream.new(@output))
+            @output = MockOutput.new(1, :num_channels => 1)
+            @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
             @data = @sound.data
             @frames = AudioPlayback::Playback::FrameSet.new(@playback).slice(AudioPlayback::Playback::METADATA.size..-1)
           end

--- a/test/playback/stream_data_test.rb
+++ b/test/playback/stream_data_test.rb
@@ -4,20 +4,108 @@ class AudioPlayback::Playback::StreamDataTest < Minitest::Test
 
   context "StreamData" do
 
+    setup do
+      @path = "test/media/1-mono-44100.wav"
+      @file = AudioPlayback::File.new(@path)
+      @sound = AudioPlayback::Sound.new(@file)
+      @output = MockOutput.new(1, :num_channels => 1)
+      @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
+    end
+
+    context "#add_metadata" do
+
+      setup do
+        @data = AudioPlayback::Playback::StreamData.new(@playback)
+      end
+
+      should "add default metadata" do
+        assert_equal 0.0, @data[AudioPlayback::Playback::METADATA.index(:is_eof)]
+        assert_equal 0.0, @data[AudioPlayback::Playback::METADATA.index(:start_frame)]
+        assert_equal 0.0, @data[AudioPlayback::Playback::METADATA.index(:pointer)]
+        assert_equal @data.num_frames.to_f, @data[AudioPlayback::Playback::METADATA.index(:end_frame)]
+        assert_equal @data.num_frames.to_f, @data[AudioPlayback::Playback::METADATA.index(:size)]
+        assert_equal @playback.output.num_channels.to_f, @data[AudioPlayback::Playback::METADATA.index(:num_channels)]
+      end
+
+    end
+
+    context "#set_metadata" do
+
+      setup do
+        @data = AudioPlayback::Playback::StreamData.new(@playback)
+
+        # Validate
+        @pointer_index = AudioPlayback::Playback::METADATA.index(:pointer)
+        @eof_index = AudioPlayback::Playback::METADATA.index(:is_eof)
+
+        assert_equal 0.0, @data[@pointer_index]
+        assert_equal 0.0, @data[@eof_index]
+
+        # Set metadata to non zero values
+        @data.send(:set_metadata, :pointer, 4.0)
+        @data.send(:set_metadata, :is_eof, 1.0)
+      end
+
+      should "change values" do
+        assert_equal 4.0, @data[@pointer_index]
+        assert_equal 1.0, @data[@eof_index]
+      end
+
+    end
+
+    context "#reset" do
+
+      setup do
+        @data = AudioPlayback::Playback::StreamData.new(@playback)
+
+        # Set metadata to non zero values
+        @data.send(:set_metadata, :pointer, 4.0)
+        @data.send(:set_metadata, :is_eof, 1.0)
+
+        # Validate metadata
+        indexes = [:pointer, :is_eof].map do |key|
+          AudioPlayback::Playback::METADATA.index(key)
+        end
+        @nonzero_values = indexes.map { |index| @data[index] }
+        assert @nonzero_values.all? { |value| value > 0.0 }
+
+        # Run reset
+        @data.reset
+
+        # Collect metadata
+        @reset_values = indexes.map { |index| @data[index] }
+      end
+
+      should "reset data" do
+        refute_empty @reset_values
+        assert @reset_values.all? { |value| value == 0.0 }
+      end
+
+    end
+
     context "#to_pointer" do
 
       setup do
-        @path = "test/media/1-mono-44100.wav"
-        @file = AudioPlayback::File.new(@path)
-        @sound = AudioPlayback::Sound.new(@file)
-        @output = MockOutput.new(1, :num_channels => 1)
-        @playback = AudioPlayback::Playback.new(@sound, @output, :stream => MockStream.new(@output))
-        @data = @playback.data
+        @data = AudioPlayback::Playback::StreamData.new(@playback)
+        @pointer = @data.to_pointer
       end
 
-      should "return a stream data object" do
-        refute_nil @data
-        assert_kind_of AudioPlayback::Playback::StreamData, @data
+      should "return a ffi pointer" do
+        refute_nil @pointer
+        assert_kind_of FFI::Pointer, @pointer
+      end
+
+    end
+
+    context ".to_pointer" do
+
+      setup do
+        @pointer = AudioPlayback::Playback::StreamData.to_pointer(@playback)
+      end
+
+      should "return a ffi pointer" do
+        refute_nil @pointer
+        assert_kind_of FFI::Pointer, @pointer
       end
 
     end

--- a/test/playback_test.rb
+++ b/test/playback_test.rb
@@ -40,12 +40,12 @@ class AudioPlayback::PlaybackTest < Minitest::Test
           end
 
           should "have correct seek value" do
-            refute_nil @playback.truncate[:seek]
-            assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:seek]
+            refute_nil @playback.truncate[:start_frame]
+            assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
           end
 
           should "have no duration value" do
-            assert_nil @playback.truncate[:duration]
+            assert_nil @playback.truncate[:end_frame]
           end
 
         end
@@ -63,12 +63,12 @@ class AudioPlayback::PlaybackTest < Minitest::Test
           end
 
           should "have no seek value" do
-            assert_nil @playback.truncate[:seek]
+            assert_nil @playback.truncate[:start_frame]
           end
 
           should "have correct duration value" do
-            refute_nil @playback.truncate[:duration]
-            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:duration]
+            refute_nil @playback.truncate[:end_frame]
+            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end
@@ -86,12 +86,12 @@ class AudioPlayback::PlaybackTest < Minitest::Test
           end
 
           should "have no seek value" do
-            assert_nil @playback.truncate[:seek]
+            assert_nil @playback.truncate[:start_frame]
           end
 
           should "have correct duration value" do
-            refute_nil @playback.truncate[:duration]
-            assert_equal (@end_position * @sample_rate).to_i, @playback.truncate[:duration]
+            refute_nil @playback.truncate[:end_frame]
+            assert_equal (@end_position * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end
@@ -110,13 +110,13 @@ class AudioPlayback::PlaybackTest < Minitest::Test
           end
 
           should "have correct seek value" do
-            refute_nil @playback.truncate[:seek]
-            assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:seek]
+            refute_nil @playback.truncate[:start_frame]
+            assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
           end
 
           should "have correct duration value" do
-            refute_nil @playback.truncate[:duration]
-            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:duration]
+            refute_nil @playback.truncate[:end_frame]
+            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end
@@ -137,13 +137,13 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             end
 
             should "have correct seek value" do
-              refute_nil @playback.truncate[:seek]
-              assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:seek]
+              refute_nil @playback.truncate[:start_frame]
+              assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
             end
 
             should "have correct duration value" do
-              refute_nil @playback.truncate[:duration]
-              assert_equal ((@end_position - @seek) * @sample_rate).to_i, @playback.truncate[:duration]
+              refute_nil @playback.truncate[:end_frame]
+              assert_equal ((@end_position - @seek) * @sample_rate).to_i, @playback.truncate[:end_frame]
             end
 
           end
@@ -179,12 +179,12 @@ class AudioPlayback::PlaybackTest < Minitest::Test
           end
 
           should "have no seek value" do
-            assert_nil @playback.truncate[:seek]
+            assert_nil @playback.truncate[:start_frame]
           end
 
           should "ignore end_position, use duration" do
-            refute_nil @playback.truncate[:duration]
-            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:duration]
+            refute_nil @playback.truncate[:end_frame]
+            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end
@@ -204,13 +204,13 @@ class AudioPlayback::PlaybackTest < Minitest::Test
           end
 
           should "have correct seek value" do
-            refute_nil @playback.truncate[:seek]
-            assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:seek]
+            refute_nil @playback.truncate[:start_frame]
+            assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
           end
 
           should "ignore end_position, use duration" do
-            refute_nil @playback.truncate[:duration]
-            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:duration]
+            refute_nil @playback.truncate[:end_frame]
+            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end
@@ -218,7 +218,7 @@ class AudioPlayback::PlaybackTest < Minitest::Test
       end
 
     end
-    
+
     context ".play" do
 
       setup do

--- a/test/playback_test.rb
+++ b/test/playback_test.rb
@@ -39,7 +39,7 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             assert_kind_of Hash, @playback.truncate
           end
 
-          should "have correct seek value" do
+          should "have correct start frame value" do
             refute_nil @playback.truncate[:start_frame]
             assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
           end
@@ -62,11 +62,11 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             assert_kind_of Hash, @playback.truncate
           end
 
-          should "have no seek value" do
+          should "have no start frame value" do
             assert_nil @playback.truncate[:start_frame]
           end
 
-          should "have correct duration value" do
+          should "have correct end frame value" do
             refute_nil @playback.truncate[:end_frame]
             assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
@@ -85,11 +85,11 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             assert_kind_of Hash, @playback.truncate
           end
 
-          should "have no seek value" do
+          should "have no start frame value" do
             assert_nil @playback.truncate[:start_frame]
           end
 
-          should "have correct duration value" do
+          should "have correct end frame value" do
             refute_nil @playback.truncate[:end_frame]
             assert_equal (@end_position * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
@@ -109,14 +109,14 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             assert_kind_of Hash, @playback.truncate
           end
 
-          should "have correct seek value" do
+          should "have correct start frame value" do
             refute_nil @playback.truncate[:start_frame]
             assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
           end
 
-          should "have correct duration value" do
+          should "have correct end frame value" do
             refute_nil @playback.truncate[:end_frame]
-            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
+            assert_equal ((@duration + @seek) * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end
@@ -136,14 +136,14 @@ class AudioPlayback::PlaybackTest < Minitest::Test
               assert_kind_of Hash, @playback.truncate
             end
 
-            should "have correct seek value" do
+            should "have correct start frame value" do
               refute_nil @playback.truncate[:start_frame]
               assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
             end
 
-            should "have correct duration value" do
+            should "have correct end frame value" do
               refute_nil @playback.truncate[:end_frame]
-              assert_equal ((@end_position - @seek) * @sample_rate).to_i, @playback.truncate[:end_frame]
+              assert_equal (@end_position * @sample_rate).to_i, @playback.truncate[:end_frame]
             end
 
           end
@@ -178,7 +178,7 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             assert_kind_of Hash, @playback.truncate
           end
 
-          should "have no seek value" do
+          should "have no start frame value" do
             assert_nil @playback.truncate[:start_frame]
           end
 
@@ -203,14 +203,14 @@ class AudioPlayback::PlaybackTest < Minitest::Test
             assert_kind_of Hash, @playback.truncate
           end
 
-          should "have correct seek value" do
+          should "have correct start frame value" do
             refute_nil @playback.truncate[:start_frame]
             assert_equal (@seek * @sample_rate).to_i, @playback.truncate[:start_frame]
           end
 
           should "ignore end_position, use duration" do
             refute_nil @playback.truncate[:end_frame]
-            assert_equal (@duration * @sample_rate).to_i, @playback.truncate[:end_frame]
+            assert_equal ((@duration + @seek) * @sample_rate).to_i, @playback.truncate[:end_frame]
           end
 
         end

--- a/test/position_test.rb
+++ b/test/position_test.rb
@@ -1,0 +1,167 @@
+require "helper"
+
+class AudioPlayback::PositionTest < Minitest::Test
+
+  context "Position" do
+
+    context "#initialize" do
+
+      context "invalid" do
+
+        context "invalid number" do
+
+          should "raise exception if min above 60" do
+            assert_raises AudioPlayback::Position::InvalidTime do
+              AudioPlayback::Position.new("123:78:34.45")
+            end
+          end
+
+          should "raise exception if seconds above 60" do
+            assert_raises AudioPlayback::Position::InvalidTime do
+              AudioPlayback::Position.new("123:45:89.45")
+            end
+          end
+
+        end
+
+        context "other characters" do
+
+          should "raise exception" do
+            assert_raises AudioPlayback::Position::InvalidTime do
+              AudioPlayback::Position.new("kdjfdkdj")
+            end
+          end
+
+        end
+
+      end
+
+      context "valid" do
+
+        context "has seconds integer" do
+
+          should "populate ss" do
+            position = AudioPlayback::Position.new("12")
+            assert_equal 12.0, position.to_seconds
+          end
+
+          should "populate m:ss" do
+            position = AudioPlayback::Position.new("3:45")
+            assert_equal 225.0, position.to_seconds
+          end
+
+          should "populate mm:ss" do
+            position = AudioPlayback::Position.new("06:07")
+            assert_equal 367.0, position.to_seconds
+          end
+
+          should "populate h:mm:ss" do
+            position = AudioPlayback::Position.new("8:09:10")
+            assert_equal 29350.0, position.to_seconds
+          end
+
+          should "populate hh:mm:ss" do
+            position = AudioPlayback::Position.new("11:12:13")
+            assert_equal 40333.0, position.to_seconds
+          end
+
+        end
+
+        context "has seconds float" do
+
+          context "one digit" do
+
+            should "populate ss.s" do
+              position = AudioPlayback::Position.new("01.2")
+              assert_equal 1.2, position.to_seconds
+            end
+
+            should "populate m:ss.s" do
+              position = AudioPlayback::Position.new("3:45.6")
+              assert_equal 225.6, position.to_seconds
+            end
+
+            should "populate mm:ss.s" do
+              position = AudioPlayback::Position.new("07:59.1")
+              assert_equal 479.1, position.to_seconds
+            end
+
+            should "populate h:mm:ss.s" do
+              position = AudioPlayback::Position.new("1:23:45.6")
+              assert_equal 5025.6, position.to_seconds
+            end
+
+            should "populate hh:mm:ss.s" do
+              position = AudioPlayback::Position.new("12:34:56.7")
+              assert_equal 45296.7, position.to_seconds
+            end
+
+          end
+
+          context "two digit" do
+
+            should "populate ss.ss" do
+              position = AudioPlayback::Position.new("01.23")
+              assert_equal 1.23, position.to_seconds
+            end
+
+            should "populate m:ss.ss" do
+              position = AudioPlayback::Position.new("3:45.76")
+              assert_equal 225.76, position.to_seconds
+            end
+
+            should "populate mm:ss.ss" do
+              position = AudioPlayback::Position.new("07:59.12")
+              assert_equal 479.12, position.to_seconds
+            end
+
+            should "populate h:mm:ss.ss" do
+              position = AudioPlayback::Position.new("1:23:45.67")
+              assert_equal 5025.67, position.to_seconds
+            end
+
+            should "populate hh:mm:ss.ss" do
+              position = AudioPlayback::Position.new("12:34:56.78")
+              assert_equal 45296.78, position.to_seconds
+            end
+
+          end
+
+          context "three+ digits" do
+
+            should "populate ss.ss" do
+              position = AudioPlayback::Position.new("01.234")
+              assert_equal 1.234, position.to_seconds
+            end
+
+            should "populate m:ss.ss" do
+              position = AudioPlayback::Position.new("3:45.678")
+              assert_equal 225.678, position.to_seconds
+            end
+
+            should "populate mm:ss.ss" do
+              position = AudioPlayback::Position.new("07:39.123")
+              assert_equal 459.123, position.to_seconds
+            end
+
+            should "populate h:mm:ss.ss" do
+              position = AudioPlayback::Position.new("1:23:45.678")
+              assert_equal 5025.678, position.to_seconds
+            end
+
+            should "populate hh:mm:ss.ss" do
+              position = AudioPlayback::Position.new("12:34:56.789")
+              assert_equal 45296.789, position.to_seconds
+            end
+
+          end
+
+        end
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
https://github.com/arirusso/audio-playback/issues/2

Currently there's no way to start playback at a particular time in a sample, or play for a particular duration of time.  

This branch adds options *seek*, *duration* and *end_position* to the *Playback* class

If both *duration* and *end_position* are provided, *duration* will be used

If *seek* and *end_position* are provided, *end_position* must be greater than *seek* or *Playback::InvalidTruncation* is raised

These options are available from the command line as such:

```
* `-d` Duration. Will stop after the given amount of time.  Eg `-d 56` stops after 56 seconds of playback

* `-e` End position. Will stop at the given absolute time, irregardless of seek. Eg `-e 56` stops at 56 seconds. `-s 01:09:30 -e 01:10:00` stops at 1 hour 10 minutes after 30 seconds of playback

* `-s` Seek  to given time position. Eg `-s 56` seeks to 56 seconds and `-s 01:10:00` seeks to 1 hour 10 min.
```