### PR TITLE
Local looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Or if you're using Bundler, add this to your Gemfile
 
 * `-v` or `--verbose` Verbose
 
+* `--loop` Loop playback continuously
+
 * `--list-devices` List the available audio output devices
 
 

--- a/bin/playback
+++ b/bin/playback
@@ -26,6 +26,7 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 #
 # * `--list-devices` List the available audio output devices
 #
+# * `--loop` Loop playback continuously
 #
 
 require "audio-playback"

--- a/examples/loop.rb
+++ b/examples/loop.rb
@@ -19,7 +19,7 @@ audio_files.reject! { |file| file.match(/^\.{1,2}$/) }
 
 # Play files
 sound = AudioPlayback::Sound.load("#{MEDIA_DIRECTORY}/#{@file}")
-@playback = AudioPlayback::Playback.new(sound, @output)
+@playback = AudioPlayback::Playback.new(sound, @output, seek: 0.1, duration: 0.2)
 
 loop do
   @playback.start

--- a/examples/loop.rb
+++ b/examples/loop.rb
@@ -19,9 +19,7 @@ audio_files.reject! { |file| file.match(/^\.{1,2}$/) }
 
 # Play files
 sound = AudioPlayback::Sound.load("#{MEDIA_DIRECTORY}/#{@file}")
-@playback = AudioPlayback::Playback.new(sound, @output)
+@playback = AudioPlayback::Playback.new(sound, @output, is_looping: true)
 
-loop do
-  @playback.start
-  @playback.block
-end
+@playback.start
+@playback.block

--- a/examples/loop_snippet.rb
+++ b/examples/loop_snippet.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 $:.unshift(File.join("..", "lib"))
 
-# Loop an audio file
+# Loop a snippet of an audio file
 
 require "audio-playback"
 
@@ -19,9 +19,7 @@ audio_files.reject! { |file| file.match(/^\.{1,2}$/) }
 
 # Play files
 sound = AudioPlayback::Sound.load("#{MEDIA_DIRECTORY}/#{@file}")
-@playback = AudioPlayback::Playback.new(sound, @output)
+@playback = AudioPlayback::Playback.new(sound, @output, is_looping: true, seek: 0.1, duration: 0.2)
 
-loop do
-  @playback.start
-  @playback.block
-end
+@playback.start
+@playback.block

--- a/lib/audio-playback.rb
+++ b/lib/audio-playback.rb
@@ -34,6 +34,7 @@ module AudioPlayback
   # @option options [Array<Fixnum>, Fixnum] :channels (or: :channel) Output audio to the given channel(s).  Eg `:channels => [0,1]` will direct the audio to channels 0 and 1. Defaults to use all available channels
   # @option options [Numeric] :duration Play for given time in seconds
   # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
+  # @option options [Boolean] :is_looping (or :loop) Whether to loop audio
   # @option options [Float] :latency Latency in seconds.  Defaults to use the default latency for the selected output device
   # @option options [IO] :logger Logger object
   # @option options [Numeric] :seek Start at given time position in seconds
@@ -42,6 +43,7 @@ module AudioPlayback
     sounds = Array(file_paths).map { |path| Sound.load(path, options) }
     requested_device = options[:output_device] || options[:output]
     output = Device::Output.by_name(requested_device) || Device::Output.by_id(requested_device) || Device.default_output
+    options[:is_looping] ||= options[:loop]
     Playback.play(sounds, output, options)
   end
 

--- a/lib/audio-playback/commandline.rb
+++ b/lib/audio-playback/commandline.rb
@@ -44,6 +44,11 @@ module AudioPlayback
         :name => "List devices"
       },
 
+      :loop => {
+        :long => "--loop",
+        :name => "Loop"
+      },
+
       :seek => {
         :short => "-s",
         :long => "--seek [seconds]",

--- a/lib/audio-playback/device/stream.rb
+++ b/lib/audio-playback/device/stream.rb
@@ -180,12 +180,11 @@ module AudioPlayback
         #puts "This buffer size: #{data.size}"
         #puts "Writing to output"
         output.write_array_of_float(data)
-        counter += frames_per_buffer
-        user_data.put_float32(Playback::METADATA.index(:pointer) * Playback::FRAME_SIZE, counter.to_f) # update counter
+        next_counter = counter + frames_per_buffer
         if is_eof
           if is_looping
             #puts "Looping to beginning"
-            user_data.put_float32(Playback::METADATA.index(:pointer) * Playback::FRAME_SIZE, start_frame)
+            next_counter = start_frame
             :paContinue
           else
             #puts "Marking eof"
@@ -195,6 +194,7 @@ module AudioPlayback
         else
           :paContinue
         end
+        user_data.put_float32(Playback::METADATA.index(:pointer) * Playback::FRAME_SIZE, next_counter.to_f) # update counter
         #puts "Exiting callback at #{Time.now.to_f}"
         result
       end

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -13,7 +13,7 @@ module AudioPlayback
 
     FRAME_SIZE = FFI::TYPE_FLOAT32.size
 
-    METADATA = [:size, :num_channels, :start_frame, :end_frame, :pointer, :is_eof].freeze
+    METADATA = [:size, :num_channels, :start_frame, :end_frame, :is_looping, :pointer, :is_eof].freeze
 
     class InvalidChannels < RuntimeError
     end
@@ -45,6 +45,7 @@ module AudioPlayback
       # @option options [Array<Fixnum>, Fixnum] :channels (or: :channel)
       # @option options [Numeric] :duration Play for given time in seconds
       # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
+      # @option options [Boolean] :is_looping Whether to loop audio
       # @option options [IO] :logger
       # @option options [Numeric] :seek Start at given time position in seconds
       # @option options [Stream] :stream
@@ -108,6 +109,12 @@ module AudioPlayback
       # @return [Boolean]
       def channels_requested?
         !@channels.nil?
+      end
+
+      # Is audio looping ?
+      # @return [Boolean]
+      def looping?
+        @is_looping
       end
 
       private
@@ -212,6 +219,10 @@ module AudioPlayback
       # Populate the playback action
       # @param [Hash] options
       # @option options [Fixnum, Array<Fixnum>] :channels (or: :channel)
+      # @option options [Numeric] :duration Play for given time in seconds
+      # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
+      # @option options [Boolean] :is_looping Whether to loop audio
+      # @option options [Numeric] :seek Start at given time position in seconds
       # @return [Playback::Action]
       def populate(options = {})
         populate_channels(options)
@@ -223,6 +234,7 @@ module AudioPlayback
             raise(InvalidTruncation.new(message))
           end
         end
+        @is_looping = !!options[:is_looping]
         @data = StreamData.new(self)
         self
       end

--- a/lib/audio-playback/playback.rb
+++ b/lib/audio-playback/playback.rb
@@ -160,17 +160,13 @@ module AudioPlayback
         end
       end
 
-      # Populate the truncation parameters. Converts the seconds based arguments to number
-      # of frames
-      # @param [Hash] options
-      # @option options [Numeric] :duration Play for given time in seconds
-      # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
-      # @option options [Numeric] :seek Start at given time position in seconds
+      # Populate the truncation parameters. Converts the seconds based Position arguments
+      # to number of frames
+      # @param [Position, nil] seek Start at given time position in seconds
+      # @param [Position, nil] duration Play for given time in seconds
+      # @param [Position, nil] end_position Stop at given time position in seconds (will use duration arg if both are included)
       # @return [Hash]
-      def populate_truncation(options = {})
-        seek = Position.new(options[:seek]) unless options[:seek].nil?
-        duration = Position.new(options[:duration]) unless options[:duration].nil?
-        end_position = Position.new(options[:end_position]) unless options[:end_position].nil?
+      def populate_truncation(seek, duration, end_position)
         @truncate = {}
         end_position = if duration.nil?
           end_position
@@ -217,6 +213,19 @@ module AudioPlayback
         !options[:seek].nil? || !options[:duration].nil? || !options[:end_position].nil?
       end
 
+      # Populate Position objects using the the truncation parameters.
+      # @param [Hash] options
+      # @option options [Numeric] :duration Play for given time in seconds
+      # @option options [Numeric] :end_position Stop at given time position in seconds (will use :duration if both are included)
+      # @option options [Numeric] :seek Start at given time position in seconds
+      # @return [Array<Position>]
+      def truncate_options_as_positions(options = {})
+        seek = Position.new(options[:seek]) unless options[:seek].nil?
+        duration = Position.new(options[:duration]) unless options[:duration].nil?
+        end_position = Position.new(options[:end_position]) unless options[:end_position].nil?
+        [seek, duration, end_position]
+      end
+
       # Populate the playback action
       # @param [Hash] options
       # @option options [Fixnum, Array<Fixnum>] :channels (or: :channel)
@@ -229,7 +238,8 @@ module AudioPlayback
         populate_channels(options)
         if truncate_requested?(options)
           if truncate_valid?(options)
-            populate_truncation(options)
+            seek, duration, end_position = *truncate_options_as_positions(options)
+            populate_truncation(seek, duration, end_position)
           else
             message = "Truncation options are not valid"
             raise(InvalidTruncation.new(message))


### PR DESCRIPTION
There's a pause at the end of a file in playback when looping

This branch removes the pause by looping using the local audio pointer rather than resetting the PortAudio stream repeatedly

When looping is active and playback finishes, the PortAudio *paComplete* callback is no longer fired.  The audio pointer is reset to equal the playback start frame and *paContinue* is fired

Non-looping audio is unaffected